### PR TITLE
Add workflow tracking schema and API endpoints

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -4,9 +4,32 @@ import httpx
 import json
 import websockets
 import os
+from typing import Optional
 
 API_BASE = os.getenv("API_BASE", "http://localhost:8000")
 AGENT_WS = os.getenv("AGENT_WS", "ws://localhost:8765")
+
+
+def start_workflow(name: str):
+    """Start a workflow run and return its metadata."""
+    with httpx.Client() as client:
+        response = client.post(
+            f"{API_BASE}/workflows", json={"name": name}, timeout=10
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def record_workflow_step(run_id: int, name: str, status: str, result: Optional[str] = None):
+    """Record a step's progress for a workflow run."""
+    with httpx.Client() as client:
+        response = client.post(
+            f"{API_BASE}/workflows/{run_id}/steps",
+            json={"name": name, "status": status, "result": result},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
 
 
 def search_customers(name: str = None, location: str = None, criteria: str = None):

--- a/backend/models.py
+++ b/backend/models.py
@@ -85,3 +85,32 @@ class EmailCreate(BaseModel):
     to: str
     subject: str
     body: str
+
+
+class WorkflowRun(BaseModel):
+    id: int
+    name: str
+    status: str
+    started_at: str
+    finished_at: Optional[str] = None
+    result: Optional[str] = None
+
+
+class WorkflowRunCreate(BaseModel):
+    name: str
+
+
+class WorkflowStep(BaseModel):
+    id: int
+    run_id: int
+    name: str
+    status: str
+    started_at: str
+    finished_at: Optional[str] = None
+    result: Optional[str] = None
+
+
+class WorkflowStepCreate(BaseModel):
+    name: str
+    status: str
+    result: Optional[str] = None


### PR DESCRIPTION
## Summary
- define Pydantic models for workflow runs and steps
- add SQLite tables and API endpoints to start workflows, record step progress, and query runs
- expose helper functions in agent tools to start workflows and log steps

## Testing
- `python -m py_compile backend/models.py backend/app.py agent/tools.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a438f6c1d4832caf4ff501bdfb6992