### PR TITLE
feat: dynamic component factory and intents

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -94,6 +94,17 @@ async def emit_intent(intent: dict):
         return {"status": "error", "message": str(e)}
 
 
+async def tool_add_component(component: str, component_id: str, props: dict | None = None):
+    """Dynamically add a UI component by emitting an intent to the frontend."""
+    intent = {
+        "type": "add_component",
+        "id": component_id,
+        "component": component,
+        "props": props or {},
+    }
+    return await emit_intent(intent)
+
+
 def get_customer_stats(metric: str):
     """Get customer analytics and statistics."""
     with httpx.Client() as client:

--- a/frontend/src/components/ComponentFactory.tsx
+++ b/frontend/src/components/ComponentFactory.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import ChartRenderer from "./ChartRenderer";
+import ChatInterface from "./ChatInterface";
+import WorkflowProgress from "./WorkflowProgress";
+
+const componentRegistry: Record<string, React.ComponentType<any>> = {
+  ChartRenderer,
+  ChatInterface,
+  WorkflowProgress,
+};
+
+export const ComponentFactory: React.FC<{ component: string; props?: any }> = ({ component, props }) => {
+  const Comp = componentRegistry[component];
+  if (!Comp) return null;
+  return <Comp {...props} />;
+};
+
+export default componentRegistry;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,6 +13,7 @@ import CalendarView from "./views/CalendarView";
 import WorkflowView from "./views/WorkflowView";
 import NotesPanel from "./panels/NotesPanel";
 import ChatInterface from "./components/ChatInterface";
+import { ComponentFactory } from "./components/ComponentFactory";
 import "./index.css";
 
 function App() {
@@ -166,6 +167,9 @@ function App() {
                       <NotesPanel />
                     </motion.div>
                   )}
+                  {Object.entries(registry.components).map(([id, cfg]) => (
+                    <ComponentFactory key={id} component={cfg.component} props={cfg.props} />
+                  ))}
                 </motion.div>
               </AnimatePresence>
             </div>

--- a/frontend/src/registry.ts
+++ b/frontend/src/registry.ts
@@ -2,7 +2,10 @@ export type ViewIntent =
   | { type: "set_view"; view_id: "customer-list" | "customer-detail" | "triage" | "dashboard" | "analytics" | "timeline" | "calendar" | "workflow" }
   | { type: "add_panel"; panel: "NotesPanel" }
   | { type: "remove_panel"; panel: "NotesPanel" }
-  | { type: "render_chart"; chartConfig: any; containerId: string; title?: string; description?: string };
+  | { type: "render_chart"; chartConfig: any; containerId: string; title?: string; description?: string }
+  | { type: "add_component"; id: string; component: string; props?: any }
+  | { type: "update_component_props"; id: string; props: any }
+  | { type: "remove_component"; id: string };
 
 export const registry = {
   currentView: "customer-list" as "customer-list" | "customer-detail" | "triage" | "dashboard" | "analytics" | "timeline" | "calendar" | "workflow",
@@ -19,7 +22,8 @@ export const registry = {
   constraints: {
     NotesPanel: { mustMountWithin: ["EntityDetail", "TriageBoard"] }
   },
-  charts: {} as Record<string, { chartConfig: any; title?: string; description?: string }>
+  charts: {} as Record<string, { chartConfig: any; title?: string; description?: string }>,
+  components: {} as Record<string, { component: string; props: any }>
 };
 
 export function applyIntent(intent: ViewIntent) {
@@ -44,5 +48,24 @@ export function applyIntent(intent: ViewIntent) {
     };
     // Auto-switch to analytics view if chart is rendered
     registry.currentView = "analytics";
+  }
+  if (intent.type === "add_component") {
+    registry.components[intent.id] = {
+      component: intent.component,
+      props: intent.props || {}
+    };
+  }
+  if (intent.type === "update_component_props") {
+    if (registry.components[intent.id]) {
+      registry.components[intent.id].props = {
+        ...registry.components[intent.id].props,
+        ...intent.props
+      };
+    }
+  }
+  if (intent.type === "remove_component") {
+    if (registry.components[intent.id]) {
+      delete registry.components[intent.id];
+    }
   }
 }


### PR DESCRIPTION
## Summary
- extend frontend registry with component-based intents and state
- add React component factory for dynamic rendering
- expose `tool_add_component` for agents to emit add-component intents

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Property 'env' does not exist on type 'ImportMeta')
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a438ed8b14832cb673414616fbdcc2