### PR TITLE
feat: handle client events

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -94,6 +94,35 @@ async def emit_intent(intent: dict):
         return {"status": "error", "message": str(e)}
 
 
+def tool_receive_event(event: dict):
+    """Process events received from the frontend.
+
+    Events can trigger workflows or update internal state. The payload
+    structure is expected to be a dictionary.
+    """
+
+    event_type = event.get("type")
+
+    # Workflow execution request
+    if event_type == "workflow":
+        workflow = event.get("name")
+        context = event.get("context", {})
+        if workflow:
+            return execute_workflow(workflow, context)
+        return {"status": "error", "message": "missing workflow name"}
+
+    # Persist arbitrary state
+    if event_type == "state":
+        key = event.get("key")
+        value = event.get("value", {})
+        if key:
+            return set_workflow_state(key, value)
+        return {"status": "error", "message": "missing state key"}
+
+    # Default: acknowledge receipt
+    return {"status": "received", "event": event}
+
+
 def get_customer_stats(metric: str):
     """Get customer analytics and statistics."""
     with httpx.Client() as client:

--- a/frontend/src/agentSocket.ts
+++ b/frontend/src/agentSocket.ts
@@ -9,6 +9,14 @@ export function setForceRender(fn: () => void) {
   forceRender = fn;
 }
 
+export function sendEvent(payload: Record<string, unknown>) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: "event", payload }));
+  } else {
+    console.warn("Agent WebSocket not connected");
+  }
+}
+
 function connectWebSocket() {
   try {
     ws = new WebSocket(WS_URL);


### PR DESCRIPTION
## Summary
- allow websocket server to consume frontend JSON messages and dispatch them to agent tools
- expose `sendEvent` helper in frontend to push events to server
- add `tool_receive_event` for processing inbound events and triggering workflows or state updates

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: src/agentSocket.ts(3,28): Property 'env' does not exist on type 'ImportMeta')*

------
https://chatgpt.com/codex/tasks/task_e_68a438ec8184832cb5d5862fd75a4f8d